### PR TITLE
add release workflow to automate release for new tag

### DIFF
--- a/.github/workflows/release-for-new-tag.yml
+++ b/.github/workflows/release-for-new-tag.yml
@@ -1,0 +1,13 @@
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body: "This release corresponds to the latest of the same major version for the SAF CLI."

--- a/.github/workflows/release-for-new-tag.yml
+++ b/.github/workflows/release-for-new-tag.yml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   build:
@@ -8,6 +11,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           body: "This release corresponds to the latest of the same major version for the SAF CLI."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# (WIP) saf_action
+# saf_action
 GitHub Action for the [SAF CLI](https://github.com/mitre/saf)
 
 ## Input and Output Arguments

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
Changes:
- This new workflow will automatically build the release after a new tag is pushed to the repo on main. For example, if someone does `git tag v1.0.0` then `git push --tags` it will initiate a release called "v1.0.0" with the tag "v1.0.0" using the latest commit on the `main` branch. "v1.0.0" is an example. It can be tagged however desired.
- Eliminated _config.yml because we are not using a Github page for this action.
- Deleted (wip)