### PR TITLE
Update release automated notes

### DIFF
--- a/.github/workflows/release-for-new-tag.yml
+++ b/.github/workflows/release-for-new-tag.yml
@@ -9,7 +9,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+      - name: Get Release Notes
+        run: |
+          echo "$(git tag -l --sort=taggerdate --format="%(contents:subject)" | tail -n 1)" > RELEASE_NOTES
+          echo "This release corresponds to the latest of the same major version for the SAF CLI." >> RELEASE_NOTES
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          body: "This release corresponds to the latest of the same major version for the SAF CLI."
+          body_path: RELEASE_NOTES


### PR DESCRIPTION
Updated release workflow as follows:
- Added `ref: ${{ github.ref }}` to access latest tag information in GitHub Action virtual environment. If no tag is found, it will get the commit message.
- Made tag annotation part of the generated release notes `echo "$(git tag -l --sort=taggerdate --format="%(contents:subject)" | tail -n 1)" > RELEASE_NOTES`. If no annotation is added, it will get the commit message.
- Use the contents of the `RELEASE_NOTES` file as the generated release notes `body_path: RELEASE_NOTES`